### PR TITLE
Change `deploycsw` from expect to bash

### DIFF
--- a/dockerfiles/csw/bin/deploycsw
+++ b/dockerfiles/csw/bin/deploycsw
@@ -1,14 +1,3 @@
-#!/usr/bin/expect -f
+#!/bin/bash -xe
 
-set envname [lindex $argv 0]
-
-set timeout -1
-
-spawn /usr/local/bin/gulp environment.deploy --env=$envname
-
-expect "Are you sure*"
-send -- "yes\r"
-expect "Are you sure*"
-send -- "yes\r"
-
-expect eof
+/usr/local/bin/gulp environment.deploy --env="${0}"


### PR DESCRIPTION
The `deploycsw` script was swallowing errors from its child `gulp`
task. This was causing the concourse task to complete succesfully
even though the The expect script was only used to accept the SSH host keys from
the bastion and dev hosts. I have changed the `gulp` task to auto-add
the ssh hostkey-fingerprints from bastion and dev host.