### PR TITLE
Update csw-chalice Dockerfile to use cyber-security-concourse-base-image

### DIFF
--- a/dockerfiles/chalice/Dockerfile
+++ b/dockerfiles/chalice/Dockerfile
@@ -1,22 +1,10 @@
-FROM ubuntu:18.04
-
-ENV TF_VERSION 0.11.14
-ENV TF_CHECKSUM 9b9a4492738c69077b079e595f5b2a9ef1bc4e8fb5596610f69a6f322a8af8dd
-
-# expect need local time zone
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-LABEL ubuntu="18.04"
-LABEL terraform="$TF_VERSION"
-LABEL user="gdscyber"
+FROM gdscyber/cyber-security-concourse-base-image
 
 RUN apt-get update -y
-RUN apt-get install -y python3.6 python3-distutils python3-pip
-RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
-RUN apt-get install -y python3-venv
+# cyber-security-concourse-base-image installs python3.7-venv, it *should* work
+# RUN apt-get install -y python3-venv
 RUN apt-get install -y nodejs npm
-RUN apt-get install -y expect awscli jq curl unzip git
+RUN apt-get install -y expect
 
 # install n and upgrade node to n stable
 RUN npm install -g n
@@ -27,16 +15,5 @@ RUN npm install -g gulp-cli
 
 # install npm-reinstall
 # RUN npm install -g npm-reinstall
-
-# Python 3 encoding set
-ENV LANG C.UTF-8
-
-# install terraform
-WORKDIR /tmp
-
-RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip > terraform.zip && \
-    echo "${TF_CHECKSUM}  terraform.zip"  > terraform.sha && \
-    sha256sum -c terraform.sha && unzip terraform.zip && mv terraform /usr/bin/terraform                    && \
-    rm terraform.zip && rm terraform.sha
 
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
Closes #14, part of https://github.com/alphagov/cyber-security-concourse-base-image/pull/26

To test it, I built it locally, which worked fine. I'm not sure how it will affect the pipeline it's a part of though - presumably there shouldn't be any changes, but ...